### PR TITLE
nodejs-canary to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 2.3.89
 - name: nodejs-canary
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: stateful-voting-app-worker-java
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.5


### PR DESCRIPTION
Promote nodejs-canary to version 0.0.6